### PR TITLE
Braces on single line blocks and spaces before parentheses when required

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -83,6 +83,7 @@ IndentGotoLabels: true
 IndentPPDirectives: None
 IndentWidth:     4
 IndentWrappedFunctionNames: false
+InsertBraces: true
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true

--- a/.clang-format
+++ b/.clang-format
@@ -113,7 +113,10 @@ SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: true
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterFunctionDefinitionName: true
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false

--- a/README.md
+++ b/README.md
@@ -15,4 +15,3 @@ This is a `.clang-format` file that attempts to implement the [Barr Group's form
 
 1. Align trailing comments doesn't always work on multi-line top-level function definitions
 2. [Pre-processor indentation affects nearby comment spacing](https://github.com/petertorelli/clang-format-barr-c/issues/2)
-3. [Add InsertBraces](https://github.com/petertorelli/clang-format-barr-c/issues/4)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
-# Introduction
+# Config file for clang-format to implement BARR-C
 
 This is a `.clang-format` file that attempts to implement the [Barr Group's formatting standards for embedded C](https://barrgroup.com/embedded-systems/books/embedded-c-coding-standard) via the [`clang-format`](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) tool.
 
-Issues:
+## Usage
+
+1. Install clang-format in one of the following ways:
+ - From package manager (e.g. `sudo apt-get install clang-format`)
+ - Download the entire [LLVM toolchain](http://llvm.org/releases/) and extract the `clang-format` binary. Just extract the `.tar.xz` file and copy `bin/clang-format` into your `PATH` (e.g. `/usr/local/bin`).
+2. Copy [.clang-format](.clang-format) from this repository to your local directory
+3. Run `clang-format -i *.{c,h,cpp,hpp}` to format all c/c++ files in the folder
+4. Optionally, you can [integrate clang-format with your IDE](https://clang.llvm.org/docs/ClangFormat.html)
+
+## Known Issues:
 
 1. Space before parantheses should only happen during declaration and not call instances, there is no provision for this.
 2. Align trailing comments doesn't always work on multi-line top-level function definitions
-3. Pre-processor indentation affects nearby comment spacing
-4. ~~There's no provision for aligning consecutive variable declarations for pointers (i.e., no space after the `*` but still aligned text excluding the `*`).~~ `clang-format` v14 now right-aligns pointers correctly.
-
+3. [Pre-processor indentation affects nearby comment spacing](https://github.com/petertorelli/clang-format-barr-c/issues/2)
+4. [Add InsertBraces](https://github.com/petertorelli/clang-format-barr-c/issues/4)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This is a `.clang-format` file that attempts to implement the [Barr Group's form
 
 ## Known Issues:
 
-1. Space before parantheses should only happen during declaration and not call instances, there is no provision for this.
-2. Align trailing comments doesn't always work on multi-line top-level function definitions
-3. [Pre-processor indentation affects nearby comment spacing](https://github.com/petertorelli/clang-format-barr-c/issues/2)
-4. [Add InsertBraces](https://github.com/petertorelli/clang-format-barr-c/issues/4)
+1. Align trailing comments doesn't always work on multi-line top-level function definitions
+2. [Pre-processor indentation affects nearby comment spacing](https://github.com/petertorelli/clang-format-barr-c/issues/2)
+3. [Add InsertBraces](https://github.com/petertorelli/clang-format-barr-c/issues/4)


### PR DESCRIPTION
Dear Peter:

Thank you so much for your project. It saved me a lot of time.

I am doing a PR with the following changes:

1. Add spaces before parentheses on function declarations (Listed as TODO in the readme)
2. Insert Braces on single line indented blocks (https://github.com/petertorelli/clang-format-barr-c/issues/4)
3. Updating the readme to reflect this changes + some instructions on how to set up clang-format

All of this was tested with clang-15 from ubuntu-22-04's binaries.

Thank you again!