### PR TITLE
3.1.j - Added AfterFunctionDeclarationName to SpaceBeforeParensOptions 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -118,6 +118,7 @@ SpaceBeforeParens: Custom
 SpaceBeforeParensOptions:
   AfterControlStatements: true
   AfterFunctionDefinitionName: true
+  AfterFunctionDeclarationName: true
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false


### PR DESCRIPTION
Added AfterFunctionDeclarationName to SpaceBeforeParensOptions to conform with 3.1.j

3.1.j - The left and right parentheses of the function call operator shall always be without surrounding spaces, except that the function declaration shall feature one space between the function name and the left parenthesis to allow that one particular mention of the function name to be easily located